### PR TITLE
build.sh updated with --with-gtest option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ export AXIS2C_HOME
 
 echo "AXIS2C_HOME = ${AXIS2C_HOME}"
 
-sh configure --prefix=${AXIS2C_HOME} --enable-tests=yes 
+sh configure --prefix=${AXIS2C_HOME} --enable-tests=yes --with-gtest=/usr/src/googletest/googletest
 make -j 10 
 make install
 


### PR DESCRIPTION
Adding --with-gtest=/usr/src/googletest/googletest avoids build failure when building the source using build.sh 